### PR TITLE
Versatilityless ltsvparser

### DIFF
--- a/axslog/axslog.go
+++ b/axslog/axslog.go
@@ -2,6 +2,7 @@ package axslog
 
 import (
 	"strconv"
+	"unsafe"
 )
 
 // Reader :
@@ -17,4 +18,14 @@ func SFloat64(val string) (float64, error) {
 // SInt :
 func SInt(val string) (int, error) {
 	return strconv.Atoi(val)
+}
+
+// BFloat64 :
+func BFloat64(b []byte) (float64, error) {
+	return strconv.ParseFloat(*(*string)(unsafe.Pointer(&b)), 64)
+}
+
+// BInt :
+func BInt(b []byte) (int, error) {
+	return strconv.Atoi(*(*string)(unsafe.Pointer(&b)))
 }

--- a/ltsvreader/ltsvreader.go
+++ b/ltsvreader/ltsvreader.go
@@ -2,8 +2,8 @@ package ltsvreader
 
 import (
 	"bufio"
+	"bytes"
 	"io"
-	"strings"
 
 	"github.com/kazeburo/mackerel-plugin-axslog/axslog"
 	"go.uber.org/zap"
@@ -14,39 +14,44 @@ var statusFlag = 2
 
 // Reader struct
 type Reader struct {
-	bufscan   *bufio.Scanner
-	logger    *zap.Logger
-	ptimeKey  string
-	statusKey string
+	bufscan       *bufio.Scanner
+	logger        *zap.Logger
+	ptimeKey      string
+	statusKey     string
+	bytePtimeKey  []byte
+	byteStatusKey []byte
 }
 
 // New :
 func New(ir io.Reader, logger *zap.Logger, ptimeKey string, statusKey string) *Reader {
 	bs := bufio.NewScanner(ir)
-	return &Reader{bs, logger, ptimeKey, statusKey}
+	return &Reader{bs, logger, ptimeKey, statusKey, []byte(ptimeKey), []byte(statusKey)}
 }
 
+var bTab = []byte("\t")
+var bCol = []byte(":")
+
 // ParseLTSV :
-func ParseLTSV(d1 string, ptimeKey, statusKey string) (int, string, string) {
+func ParseLTSV(d1, ptimeKey, statusKey []byte) (int, []byte, []byte) {
 	c := 0
-	var pt string
-	var st string
+	var pt []byte
+	var st []byte
 	p1 := 0
 	for {
-		p2 := strings.Index(d1[p1:], "\t")
+		p2 := bytes.Index(d1[p1:], bTab)
 		if p2 < 0 {
 			break
 		}
-		p3 := strings.Index(d1[p1:p1+p2], ":")
+		p3 := bytes.Index(d1[p1:p1+p2], bCol)
 		if p3 < 0 {
 			break
 		}
-		if d1[p1:p1+p3] == ptimeKey {
+		if bytes.Equal(d1[p1:p1+p3], ptimeKey) {
 			pt = d1[p1+p3+1 : p1+p2]
 			c = c | ptimeFlag
 		}
 
-		if d1[p1:p1+p3] == statusKey {
+		if bytes.Equal(d1[p1:p1+p3], statusKey) {
 			st = d1[p1+p3+1 : p1+p2]
 			c = c | statusFlag
 		}
@@ -58,7 +63,7 @@ func ParseLTSV(d1 string, ptimeKey, statusKey string) (int, string, string) {
 // Parse :
 func (r *Reader) Parse() (float64, int, error) {
 	for r.bufscan.Scan() {
-		c, pt, st := ParseLTSV(r.bufscan.Text(), r.ptimeKey, r.statusKey)
+		c, pt, st := ParseLTSV(r.bufscan.Bytes(), r.bytePtimeKey, r.byteStatusKey)
 		if c&ptimeFlag == 0 {
 			r.logger.Warn("No ptime in ltsv. continue", zap.String("key", r.ptimeKey))
 			continue
@@ -67,12 +72,12 @@ func (r *Reader) Parse() (float64, int, error) {
 			r.logger.Warn("No status in ltsv. continue", zap.String("key", r.statusKey))
 			continue
 		}
-		ptime, err := axslog.SFloat64(pt)
+		ptime, err := axslog.BFloat64(pt)
 		if err != nil {
 			r.logger.Warn("Failed to convert ptime. continue", zap.Error(err))
 			continue
 		}
-		status, err := axslog.SInt(st)
+		status, err := axslog.BInt(st)
 		if err != nil {
 			r.logger.Warn("Failed to convert status. continue", zap.Error(err))
 			continue

--- a/main.go
+++ b/main.go
@@ -209,6 +209,12 @@ func getStats(opts cmdOpts, logger *zap.Logger) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to update pos file")
 	}
+	logger.Info("Analyzing Succeeded",
+		zap.String("logfile", opts.LogFile),
+		zap.Int64("startPos", lastPos),
+		zap.Int64("endPos", fpr.Pos),
+		zap.Float64("Rows", sc["total"]),
+	)
 	return nil
 }
 


### PR DESCRIPTION
For getting more performance, removed map from ltsvparser and made it versatility less.

after

```
real    0m1.847s
user    0m1.668s
sys     0m0.212s
```

before

```
real    0m4.202s
user    0m4.347s
sys     0m0.334s
```

Around 400MB, 1M rows ltsv log.