### PR TITLE
Continue if hyphen

### DIFF
--- a/ltsvreader/ltsvreader.go
+++ b/ltsvreader/ltsvreader.go
@@ -49,7 +49,8 @@ PARSE_LTSV:
 
 		// `-` はskip
 		if bytes.Equal(d1[p1+p3+1:p1+p2], bHif) {
-			break
+			p1 += p2 + 1
+			continue
 		}
 
 		if bytes.Equal(d1[p1:p1+p3], r.bytePtimeKey) {


### PR DESCRIPTION
@kazeburo 

If there is a hyphen in the middle of the log, parsing will end.(referer:-)

#### test log file

```
time:2022-12-14T03:29:26+09:00	host:0.0.0.0	remote_addr:1.1.1.1	status:200	request_time:0.001	referer:-	user_agent:curl/7.81.0	upstream_addr:2.2.2.2:443	upstream_response_time:0.001
```

#### run 

I want to display the numerical value of upstream_response_time.

```
$ ./mackerel-plugin-axslog --key-prefix=tmp --logfile=./test.log --ptime-key=upstream_response_time
2022/12/14 18:28:41 Analysis start logFile:./test2.log lastPos:0 Size:260
2022/12/14 18:28:41 No ptime. continue key:upstream_response_time
2022/12/14 18:28:41 Analysis completed logFile:./test.log startPos:0 endPos:260 Rows:0
axslog.access_num_tmp.1xx_count	0.000000	1671010121
axslog.access_num_tmp.2xx_count	0.000000	1671010121
axslog.access_num_tmp.3xx_count	0.000000	1671010121
axslog.access_num_tmp.4xx_count	0.000000	1671010121
axslog.access_num_tmp.499_count	0.000000	1671010121
axslog.access_num_tmp.5xx_count	0.000000	1671010121
axslog.access_total_tmp.count	0.000000	1671010121
```