### PR TITLE
introduced --invert-filter

### DIFF
--- a/axslog/axslog.go
+++ b/axslog/axslog.go
@@ -30,8 +30,9 @@ type CmdOpts struct {
 	KeyPrefix        string   `long:"key-prefix" description:"Metric key prefix" required:"true"`
 	PtimeKey         string   `long:"ptime-key" default:"ptime" description:"key name for request_time"`
 	StatusKeys       []string `long:"status-key" default:"status" description:"key name for response status"`
-	Filter           string   `long:"filter" default:"" description:"text for filtering log"`
+	Filter           string   `long:"filter" default:"" description:"select lines contain a specified text from log"`
 	SkipUntilBracket bool     `long:"skip-until-json" description:"skip reading until first { for json log with plain text header"`
+	InvertFilter     bool     `long:"invert-filter" description:"select lines don't contain a specified text from log if a filter is specified"`
 	Version          bool     `short:"v" long:"version" description:"Show version"`
 }
 

--- a/main.go
+++ b/main.go
@@ -46,8 +46,14 @@ func parseLog(bs *bufio.Scanner, r axslog.Reader, opts axslog.CmdOpts) (float64,
 	for bs.Scan() {
 		b := bs.Bytes()
 		if len(filter) > 0 {
-			if !bytes.Contains(b, filter) {
-				continue
+			if opts.InvertFilter {
+				if bytes.Contains(b, filter) {
+					continue
+				}
+			} else {
+				if !bytes.Contains(b, filter) {
+					continue
+				}
 			}
 		}
 		if opts.SkipUntilBracket {


### PR DESCRIPTION
If this option is specified, `mackerel-plugin-axslog` selects lines don't contain a specified text by `--filter`. The motivation I would like to introduce this option is to exclude some line can be noizy from a log.