### PR TITLE
ignore security hostspot on md5

### DIFF
--- a/main.go
+++ b/main.go
@@ -276,7 +276,9 @@ func getStats(opts axslog.CmdOpts) error {
 	for _, l := range logfiles {
 		logfile := l
 		go func() {
+			// BEGIN-NOSCAN
 			md5 := md5.Sum([]byte(logfile))
+			// END-NOSCAN
 			posFile := filepath.Join(tmpDir, fmt.Sprintf("%s-axslog-v4-%s-%x", uid, opts.KeyPrefix, md5))
 			stats, err := getFileStats(opts, posFile, logfile)
 			sCh <- axslog.StatsCh{


### PR DESCRIPTION
it's used only tmpfile name
